### PR TITLE
NOT READY TO MERGE 05 12 19 get heart attack recipes

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ var logger = require('morgan');
 
 var indexRouter = require('./routes/index');
 var boringQueryRouter = require('./routes/api/v1/boring_query');
+var heartAttackQueryRouter = require('./routes/api/v1/heart_attack_query');
 
 var app = express();
 
@@ -18,5 +19,6 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
 app.use('/api/v1/recipes', boringQueryRouter);
+app.use('/api/v1/recipes/heart-attack', heartAttackQueryRouter);
 
 module.exports = app;

--- a/migrations/20190511010115-create-boring-query-recipes.js
+++ b/migrations/20190511010115-create-boring-query-recipes.js
@@ -37,6 +37,6 @@ module.exports = {
     });
   },
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('BoringQueryRecipe');
+    return queryInterface.dropTable('BoringQueryRecipes');
   }
 };

--- a/routes/api/v1/boring_query.js
+++ b/routes/api/v1/boring_query.js
@@ -14,7 +14,7 @@ router.get("/", async (req, res, next) => {
     // create url for Edamam using the query from the param
     const appId = process.env.EDAMAM_ID
     const appKey = process.env.EDAMAM_KEY
-    url = `https://api.edamam.com/search?q=${searchQuery}&app_id=${appId}&app_key=${appKey}&calories=2000-999999&to=30`
+    const url = `https://api.edamam.com/search?q=${searchQuery}&app_id=${appId}&app_key=${appKey}&calories=2000-999999&to=30`
 
     return findOrFetchRecipes(searchQuery, BoringQuery, url, BoringQueryRecipe)
     .then(recipes => {

--- a/routes/api/v1/heart_attack_query.js
+++ b/routes/api/v1/heart_attack_query.js
@@ -1,0 +1,157 @@
+var express = require("express");
+var router = express.Router();
+var Recipe = require('../../../models').Recipe;
+var HeartAttackQuery = require('../../../models').HeartAttackQuery;
+var HeartAttackQueryRecipe = require('../../../models').HeartAttackQueryRecipe;
+const fetch = require('node-fetch');
+var pry = require('pryjs');
+
+router.get("/", async (req, res, next) => {
+  res.setHeader("Content-Type", "application/json");
+  if (!req.query.query) {
+    res.status(404).send({
+      error: "Missing recipe search query."
+    })
+  } else {
+    const searchQuery = req.query.query.toLowerCase();
+    // create url for Edamam using the query from the param
+    const appId = process.env.EDAMAM_ID
+    const appKey = process.env.EDAMAM_KEY
+    const recipeFilter = '&nutrientsFAT=300+&nutrientsNA=3000+&nutrientsSUGAR=200+'
+    const url = `https://api.edamam.com/search?q=${searchQuery}&app_id=${appId}&app_key=${appKey}&calories=2000-999999&to=30${recipeFilter}`
+
+    return findOrFetchRecipes(searchQuery, HeartAttackQuery, url, HeartAttackQueryRecipe)
+      .then(recipes => {
+        res.status(200).send(JSON.stringify(recipes))
+      })
+      .catch(error => {
+        res.status(404).send({
+          error: error
+        })
+      })
+  }
+})
+
+function findOrFetchRecipes(searchQuery, queryModel, url, queryRecipeModel) {
+  return new Promise((resolve, reject) => {
+    // look in the HeartAttackQuery table for an existing query matching the request
+    queryModel.findOne({
+        where: {
+          query: searchQuery
+        }
+      })
+      .then(query => {
+        //if it is a new query
+        if (!query) {
+          //fetch new recipes from edamam api
+          getRecipes(url)
+            .then(recipeResponse => {
+              //create HeartAttackQuery, Recipes, and HeartAttackQueryRecipes in database
+              return saveHeartAttackRecipes(recipeResponse, searchQuery, queryModel, queryRecipeModel);
+            })
+            .then(recipes => {
+              //Send newly retrieved recipes. Sort by highest calorie total and only top 10 results.
+              recipes.sort((a, b) => b.calories - a.calories);
+              recipes = recipes.slice(0, 10);
+              //res.status(200).send(JSON.stringify(recipes))
+              resolve(recipes)
+            })
+            .catch(error => {
+              reject(error)
+            })
+          //If an existing query is found
+        } else {
+          // find the recipes that are already associated with the existing query
+          Recipe.findAll({
+              include: [{
+                model: queryRecipeModel,
+                attributes: [],
+                where: {
+                  HeartAttackQueryId: query.id
+                }
+              }],
+              order: [
+                ['calories', 'DESC']
+              ],
+              limit: 10
+            })
+            .then(recipes => {
+              //Send retrieved recipes.
+              resolve(recipes)
+            })
+            .catch(error => {
+              reject(error)
+            })
+        }
+      })
+      .catch(error => {
+        error = "Bad search query."
+        reject(error)
+      })
+  })
+};
+
+
+function getRecipes(url) {
+  return new Promise((resolve, reject) => {
+    fetch(url)
+      .then(response => {
+        if (response.status = 200) {
+          resolve(response.json())
+        } else {
+          reject(result.error_message)
+        }
+      })
+  })
+};
+
+function saveHeartAttackRecipes(recipeResponse, searchQuery, queryModel, queryRecipeModel) {
+  return new Promise((resolve, reject) => {
+    queryModel.create({
+        query: searchQuery
+      })
+      .then(query => {
+        resolve(parseRecipes(recipeResponse, query, queryRecipeModel));
+      })
+      .catch(error => {
+        reject(error)
+      })
+  })
+};
+
+function parseRecipes(recipeResponse, query, queryRecipeModel) {
+  return Promise.all(recipeResponse.hits.map(recipe => {
+    return saveRecipe(recipe, query, queryRecipeModel);
+  }))
+};
+
+function saveRecipe(recipe, query, queryRecipeModel) {
+  return new Promise((resolve, reject) => {
+    Recipe.findOrCreate({
+        where: {
+          name: recipe.recipe.label
+        },
+        defaults: {
+          url: recipe.recipe.url,
+          yield: recipe.recipe.yield,
+          calories: Math.round((recipe.recipe.calories / recipe.recipe.yield)),
+          image: recipe.recipe.image,
+          totalTime: recipe.recipe.totalTime
+        }
+      })
+      .then(recipe => {
+        queryRecipeModel.create({
+            HeartAttackQueryId: query.id,
+            RecipeId: recipe[0].id
+          })
+          .then(() => {
+            resolve(recipe[0])
+          })
+      })
+      .catch((error) => {
+        reject(error)
+      })
+  })
+};
+
+module.exports = router;

--- a/specs/endpoints/heart_attack_query.spec.js
+++ b/specs/endpoints/heart_attack_query.spec.js
@@ -1,0 +1,33 @@
+var specHelper = require('../spec_helper');
+var request = require("supertest");
+var app = require('../../app');
+
+describe('HeartAttackQuery Recipe index API', () => {
+  describe('Test GET /api/v1/recipes/heart-attack?query=chicken path', () => {
+    beforeAll(() => {
+      specHelper.tearDown()
+      specHelper.testSetup()
+    });
+
+    test('it should return a 200 status', () => {
+      return request(app).get("/api/v1/recipes/heart-attack?query=chicken").then(response => {
+        expect(response.status).toBe(200)
+      });
+    });
+
+    // test.skip('it should return an array of recipe objects', () => {
+    //   return request(app).get("/api/v1/recipes/heart-attack?query=chicken").then(response => {
+    //     expect(response.body).toBeInstanceOf(Array),
+    //       // expect(response.body.length).toEqual(8),
+    //       // expect(Object.keys(response.body[0])).toContain('name'),
+    //       // expect(Object.keys(response.body[0])).toContain('calories')
+    //   });
+    // });
+
+    test.skip('it should return a 404 status when unsuccessful', () => {
+      return request(app).get("/bad_path").then(response => {
+        expect(response.statusCode).toBe(404)
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Heart Attack Recipes

The params aka salt content, sugar content, etc need to be increased. then compared to the Boring query endpoint to ensure the recipes returned for the heart attack endpoint are less healthy.

Functional for new queries, but gives this error for queries already saved in the database.
I haven't yet determined if it's the HeartAttackQuery table or the HeartAttackQueryRecipe table that is giving us problems.

I checked the migrations and models for spelling/pluralization issues and that the models/migrations match those for BoringQuery and BoringQueryRecipe (since these endpoints are functional). They matched. I also droped the database, created and migrated again. This solved the issue.... until I ran the same query again, in which case it gave the same error. Therefore it's an issue with how its saving to database.

![image](https://user-images.githubusercontent.com/42525195/57588806-35bed400-74d7-11e9-8a65-912a43bb55bb.png)
